### PR TITLE
Fix/pagination goto page

### DIFF
--- a/src/app/components/basic/WinPagination.vue
+++ b/src/app/components/basic/WinPagination.vue
@@ -27,8 +27,8 @@
       />
     </div>
     <div v-if="isDirty" class="col-auto ps-1">
-      <win-button class="d-block px-2" :disabled="props.disabled || !isValidDraft" @click="goToPage">
-        {{ t('pagination.go') }}
+      <win-button class="d-block px-3" :disabled="props.disabled || !isValidDraft" @click="goToPage">
+        {{ goLabel }}
       </win-button>
     </div>
   </div>
@@ -63,6 +63,10 @@
   const isValidDraft = computed(() => {
     const value = Number(page.value);
     return Number.isInteger(value) && value >= 1 && value <= props.pages;
+  });
+  const goLabel = computed(() => {
+    const value = Number(page.value);
+    return Number.isFinite(value) ? t('pagination.go_to_page', { n: value }) : t('pagination.go');
   });
 
   function commit(newPage: number): void {

--- a/src/app/components/basic/WinPagination.vue
+++ b/src/app/components/basic/WinPagination.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="row gx-0 pagination">
-    <div v-if="page > 1" class="col-4 pe-1">
+  <div class="row gx-0 flex-nowrap pagination">
+    <div v-if="activePage > 1" class="col-auto pe-1">
       <win-button
         class="d-block"
         :disabled="props.disabled"
@@ -8,17 +8,17 @@
         @click="nextPage(-1)"
       />
     </div>
-    <div class="col-4">
+    <div class="col-auto">
       <input
         ref="pageInput"
         v-model.number="page"
         type="number"
         class="d-block"
         :readonly="props.disabled"
-        @keydown="useNumberOnly"
+        @keydown="handleKeydown"
       />
     </div>
-    <div v-if="pages > 1 && page < pages" class="col-4 ps-1">
+    <div v-if="pages > 1 && activePage < pages" class="col-auto ps-1">
       <win-button
         class="d-block"
         :disabled="props.disabled"
@@ -26,11 +26,17 @@
         @click="nextPage(1)"
       />
     </div>
+    <div v-if="isDirty" class="col-auto ps-1">
+      <win-button class="d-block px-2" :disabled="props.disabled || !isValidDraft" @click="goToPage">
+        {{ t('pagination.go') }}
+      </win-button>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-  import { ref } from 'vue';
+  import { computed, ref } from 'vue';
+  import { useI18n } from 'vue-i18n';
   import { useNumberOnly } from '@app/utils/helpers.ts';
 
   const props = withDefaults(
@@ -46,23 +52,52 @@
 
   const emit = defineEmits(['change']);
 
+  const { t } = useI18n();
+
+  // page: draft value bound to the input. activePage: the page that's actually loaded.
+  // Kept separate so the arrows always step from what's loaded, never from an unsaved draft.
   const page = ref(1);
+  const activePage = ref(1);
+
+  const isDirty = computed(() => page.value !== activePage.value);
+  const isValidDraft = computed(() => {
+    const value = Number(page.value);
+    return Number.isInteger(value) && value >= 1 && value <= props.pages;
+  });
+
+  function commit(newPage: number): void {
+    page.value = newPage;
+    activePage.value = newPage;
+    emit('change', newPage);
+  }
 
   function nextPage(dir: number): void {
-    let newPage = page.value + dir;
+    let newPage = activePage.value + dir;
     if (newPage < 1) {
       newPage = 1;
     }
     if (newPage > props.pages) {
       newPage = props.pages;
     }
-    page.value = newPage;
-    emit('change', newPage);
+    commit(newPage);
+  }
+
+  function goToPage(): void {
+    if (props.disabled || !isDirty.value || !isValidDraft.value) {
+      return;
+    }
+    commit(Number(page.value));
+  }
+
+  function handleKeydown(e: KeyboardEvent): void {
+    useNumberOnly(e);
+    if (e.key === 'Enter') {
+      goToPage();
+    }
   }
 
   function reset(): void {
-    page.value = 1;
-    emit('change', page.value);
+    commit(1);
   }
 
   defineExpose({

--- a/src/app/styles/_pagination.scss
+++ b/src/app/styles/_pagination.scss
@@ -1,6 +1,6 @@
 .pagination {
   button {
-    line-height: 13px;
+    line-height: 17px;
 
     &.active {
       box-shadow: 1px 1px 0 0 black inset;

--- a/src/app/styles/_pagination.scss
+++ b/src/app/styles/_pagination.scss
@@ -1,6 +1,4 @@
 .pagination {
-  width: 100px;
-
   button {
     line-height: 13px;
 
@@ -14,6 +12,7 @@
   }
 
   input {
+    width: 34px;
     line-height: 17px;
     text-align:center;
     -moz-appearance: textfield;

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -222,7 +222,9 @@
   },
   "pagination": {
     "pages": "Pages: {n}",
-    "songs": "Songs: {n}"
+    "songs": "Songs: {n}",
+    "go": "Go",
+    "go_to_page": "Go to {n}"
   },
   "name": "English"
 }


### PR DESCRIPTION
## Problem

In the paginated windows (Play History, Ratings, User Favorites, News), the page number input and the prev/next arrow buttons share the same underlying value. Typing a page number directly into the box doesn't navigate anywhere by itself, but it does silently update the value the arrows do their math against.

So if you're on page 1 and type `30` into the box intending to jump there, then click the right arrow out of habit, you land on **31**, not 30. The arrow added 1 to your unsaved draft instead of stepping from the page that's actually loaded. From the user's perspective, nothing happens when they type, and then an unexpected page shows up when they click an arrow.

<!-- Some Screen shots -->
<img width="1162" height="867" alt="Screenshot 2026-07-07 055031" src="https://github.com/user-attachments/assets/65ccba57-11d4-49ea-be6e-c48dae1cbe6b" />
<img width="1749" height="869" alt="Screenshot 2026-07-07 055257" src="https://github.com/user-attachments/assets/8da26630-d6a7-474a-ad63-84b29406a189" />
<img width="1761" height="898" alt="Screenshot 2026-07-07 055235" src="https://github.com/user-attachments/assets/bde36d2a-b2e7-407e-8570-3b1bc6526775" />
<img width="1916" height="983" alt="Screenshot 2026-07-07 055220" src="https://github.com/user-attachments/assets/e8ae8457-b00f-41f1-89d8-20f56a258dff" />



## Fix

`WinPagination.vue` (the single component shared by all four windows above) now tracks two separate values: the draft value currently sitting in the input box, and the active page that's actually loaded.

The prev/next arrows always step from the active page and ignore any unsaved draft, which removes the surprise entirely. A "Go to {page}" button now appears next to the arrows whenever the draft differs from the active page, letting the user explicitly commit a typed page number. Pressing Enter in the box does the same thing. The button is disabled (grayed out, matching the existing disabled button styling) if the typed value is out of range.

No changes were needed in any of the four window components. They only listen for the `change` event, which still fires exactly once per committed navigation, same as before.

## Design consistency

This project's UI is a Windows 95/98 skeuomorphic recreation with a themeable design system (10 selectable themes, all built on shared CSS custom properties for bevels and colors in `styles/ui/`). The new button:

- reuses the existing `<win-button>` component as is, same bevel, same disabled state, same font
- introduces no new colors, icons, or one off styling, so it renders correctly in all 10 themes
- uses the existing i18n setup (`pagination.go_to_page`, `pagination.go` fallback) rather than a hardcoded string

The pagination row's fixed `100px` width (a leftover of the old 3 slot percentage based grid) was replaced with content sized columns so the row grows to fit the new button without affecting layout in any of the four windows that use it. Verified on both the narrowest (News at 350px) and the most crowded (User Favorites at 450px with its extra Export button).

## Testing

- Verified in Play History, Ratings, User Favorites, and News.
- Verified across all 10 themes (Windows Standard, Desert, Lilac, both High Contrast variants, High Contrast White, Rainy Day, Rose, Slate, Spruce).
- Verified: typing a page then clicking an arrow no longer overshoots, the Go button commits the typed page, Enter key behaves the same as clicking Go, out of range input disables the Go button, and layout doesn't overflow or wrap in the narrowest or most crowded window.
- `yarn lint` and `vue-tsc --noEmit` pass with no new errors introduced by this change.
